### PR TITLE
Fix jsonSchema response format for Mistral provider

### DIFF
--- a/src/providers/mistral/convert-inputs.ts
+++ b/src/providers/mistral/convert-inputs.ts
@@ -1,0 +1,31 @@
+import { ZodObject } from "zod";
+import { JsonSpecification } from "../llm-core-provider";
+import { zodSchemaToJsonSchema } from "../../shared";
+import { ResponseFormat } from "@mistralai/mistralai/src/models/components/responseformat";
+
+export const jsonResponseToMistral = (
+  format?: boolean | JsonSpecification,
+  schemaDescription?: string,
+): ResponseFormat => {
+  if (!format) {
+    return {
+      type: "text",
+    };
+  } else if (typeof format === "boolean") {
+    return {
+      type: "json_object",
+    };
+  } else if (typeof format === "object") {
+    return {
+      type: "json_schema",
+      jsonSchema: {
+        name: "json_schema",
+        description: schemaDescription,
+        schemaDefinition: format instanceof ZodObject ? zodSchemaToJsonSchema(format, "openAi") : format,
+        strict: true,
+      },
+    };
+  }
+
+  throw new Error("Invalid format");
+};

--- a/src/providers/mistral/mistral-provider.ts
+++ b/src/providers/mistral/mistral-provider.ts
@@ -11,9 +11,9 @@ import {
   LlmStreamResponseWithToolCalls,
   LlmToolCall,
   toolChoiceToOpenAi,
-  jsonResponseToOpenAi,
 } from "../../providers";
 import { LlmToolKit } from "../../tools";
+import { jsonResponseToMistral } from "./convert-inputs";
 import { convertLlmMessagesToMistralMessages } from "./convert-llm-message";
 
 interface ToolCall {
@@ -53,7 +53,7 @@ export class MistralProvider implements LlmCoreProvider {
       model,
       messages: await convertLlmMessagesToMistralMessages(messages),
       temperature,
-      responseFormat: jsonResponseToOpenAi(config.json),
+      responseFormat: jsonResponseToMistral(config.json),
       maxTokens: config.maxTokens,
       toolChoice: toolChoiceToOpenAi(config.toolChoice),
       tools: config.tools?.asLlmFunctions?.map((f) => ({
@@ -131,7 +131,7 @@ export class MistralProvider implements LlmCoreProvider {
       model,
       messages: await convertLlmMessagesToMistralMessages(messages),
       temperature,
-      responseFormat: jsonResponseToOpenAi(config.json),
+      responseFormat: jsonResponseToMistral(config.json),
       maxTokens: config.maxTokens,
       stream: true,
       tools: config.tools?.asLlmFunctions?.map((f) => ({


### PR DESCRIPTION
Closes #1

I created a copy of `jsonResponseToOpenAi` function, made result satisfy ResponseFormat from @mistralai/mistralai library and adjusted result accordingly.